### PR TITLE
Add dark mode admin and creator frontend prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,33 @@
-# diff-privacy
-Connect social media accounts
-Let us see what this can do
-# - Sujoy
+# NebulaOps Admin & Creator Portal
+
+A high-fidelity dark mode frontend prototype that showcases the admin and creator flows for a creator management platform. It follows the glowing electric aesthetic described in the design brief and is built with vanilla HTML, CSS, and JavaScript for easy previewing.
+
+## Getting Started
+
+1. Open `frontend/index.html` in any modern browser.
+2. Explore the sidebar navigation to switch between admin and creator scenarios.
+3. Toggle the `Glow Boost` control to amplify the neon glow treatment.
+4. Interact with components such as the drag-and-drop submission zone and profile tabs to see the micro-interactions in action.
+
+## Project Structure
+
+```
+frontend/
+├── index.html   # Single-page application shell with all admin & creator sections
+├── styles.css   # Dark mode theme tokens, gradients, and component styling
+└── script.js    # Navigation, tab handling, drag & drop, and glow mode logic
+```
+
+## Features
+
+- Animated admin onboarding hero with glowing CTAs and gradient cards.
+- Dashboard metrics, timelines, and guided tour overlay representation.
+- Creator module table with tabbed profile insights and glowing status chips.
+- Projects and tasks modal preview with animated progress and avatar stack.
+- Review, payouts, and Stripe Connect cards with success glow cues.
+- Creator onboarding journey, dashboard metrics, and submission interactions.
+- Component library summary for atoms, molecules, organisms, and global styles.
+
+## Browser Support
+
+Tested in Chromium-based browsers and Firefox. No build step is required—serve the `frontend` folder statically or open the HTML file directly.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,468 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin & Creator Portal</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar" aria-label="Primary navigation">
+        <div class="logo">NebulaOps</div>
+        <nav>
+          <button class="nav-btn active" data-section="admin-onboarding">Admin Onboarding</button>
+          <button class="nav-btn" data-section="admin-dashboard">Admin Dashboard</button>
+          <button class="nav-btn" data-section="admin-creators">Creators Module</button>
+          <button class="nav-btn" data-section="admin-projects">Projects &amp; Tasks</button>
+          <button class="nav-btn" data-section="admin-review">Review &amp; Submissions</button>
+          <button class="nav-btn" data-section="admin-payouts">Payouts</button>
+          <div class="divider"></div>
+          <button class="nav-btn" data-section="creator-onboarding">Creator Onboarding</button>
+          <button class="nav-btn" data-section="creator-dashboard">Creator Dashboard</button>
+          <button class="nav-btn" data-section="creator-earnings">Creator Earnings</button>
+          <div class="divider"></div>
+          <button class="nav-btn" data-section="components">Component Library</button>
+        </nav>
+        <footer class="sidebar-footer">
+          <p>Dark mode design system</p>
+        </footer>
+      </aside>
+      <main class="content" id="mainContent">
+        <header class="top-bar">
+          <div class="search-wrapper">
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M13.5 13.5L17 17"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+              />
+              <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.5"></circle>
+            </svg>
+            <input type="search" placeholder="Search anything..." />
+          </div>
+          <button class="theme-toggle" id="themeToggle">Glow Boost</button>
+        </header>
+
+        <section class="section active" id="admin-onboarding">
+          <div class="hero">
+            <div class="hero-content">
+              <h1>High-Fidelity Admin Onboarding</h1>
+              <p>
+                Welcome new admin teams with a cinematic onboarding journey. Guide them through organization
+                creation, team invitations, integrations, and dashboard discovery with ambient gradients and glowing
+                accents.
+              </p>
+              <div class="cta-group">
+                <button class="btn primary">Create Organization</button>
+                <button class="btn secondary">Watch Prototype</button>
+              </div>
+            </div>
+            <div class="hero-visual">
+              <div class="glow-orb"></div>
+              <div class="orb trail"></div>
+              <div class="orb"></div>
+            </div>
+          </div>
+
+          <div class="flow-grid">
+            <article class="card gradient">
+              <h2>1. Welcome</h2>
+              <p>Hero gradient backdrop, animated logo entry, glowing CTA to kick-off onboarding.</p>
+            </article>
+            <article class="card gradient">
+              <h2>2. Create Organization</h2>
+              <p>Floating card with soft shadow, rounded inputs and focused electric-blue outlines.</p>
+            </article>
+            <article class="card gradient">
+              <h2>3. Invite Team</h2>
+              <p>Pill-style role selectors with dynamic glow states for Admin, Finance, and Collaborator roles.</p>
+            </article>
+            <article class="card gradient">
+              <h2>4. Integrations</h2>
+              <p>Grid of integrations with Slack, Stripe, Email cards that pulse softly when connected.</p>
+            </article>
+            <article class="card gradient wide">
+              <h2>5. Dashboard Intro Overlay</h2>
+              <p>Gradient mask overlay highlights key dashboard zones with crisp white outline tooltips.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section" id="admin-dashboard">
+          <h1>Admin Dashboard Overview</h1>
+          <div class="metrics-grid">
+            <div class="metric-card" data-glow="blue">
+              <span class="label">Active Creators</span>
+              <strong class="value">1,248</strong>
+              <span class="trend positive">+12% MoM</span>
+            </div>
+            <div class="metric-card" data-glow="violet">
+              <span class="label">Pending Invites</span>
+              <strong class="value">36</strong>
+              <span class="trend neutral">Stable</span>
+            </div>
+            <div class="metric-card" data-glow="green">
+              <span class="label">Successful Payouts</span>
+              <strong class="value">$182K</strong>
+              <span class="trend positive">+8% QoQ</span>
+            </div>
+            <div class="metric-card" data-glow="yellow">
+              <span class="label">Tasks In Review</span>
+              <strong class="value">58</strong>
+              <span class="trend warning">Action Needed</span>
+            </div>
+          </div>
+
+          <div class="dashboard-layout">
+            <section class="activity-feed">
+              <h2>Activity Feed</h2>
+              <ol class="timeline">
+                <li>
+                  <div class="dot"></div>
+                  <div>
+                    <h3>Creator <span class="highlight">Mika Tan</span> submitted a review.</h3>
+                    <p>Project: AI Podcast Series · 2 minutes ago</p>
+                  </div>
+                </li>
+                <li>
+                  <div class="dot"></div>
+                  <div>
+                    <h3>Stripe payout initiated.</h3>
+                    <p>$2,400 · Finance · 12 minutes ago</p>
+                  </div>
+                </li>
+                <li>
+                  <div class="dot"></div>
+                  <div>
+                    <h3>New integration connected: Slack workspace.</h3>
+                    <p>Org: Lumina Labs · 25 minutes ago</p>
+                  </div>
+                </li>
+              </ol>
+            </section>
+            <section class="hint-overlay">
+              <h2>Guided Intro</h2>
+              <p>Enable overlay to spotlight dashboard cards with animated hints and keyboard shortcuts.</p>
+              <button class="btn outline">Launch Guided Tour</button>
+            </section>
+          </div>
+        </section>
+
+        <section class="section" id="admin-creators">
+          <h1>Creators Module</h1>
+          <div class="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>Creator</th>
+                  <th>Status</th>
+                  <th>Specialty</th>
+                  <th>Tasks</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <div class="avatar-ring active"></div>
+                    <div>
+                      <strong>Vera Lang</strong>
+                      <span class="muted">@veralang</span>
+                    </div>
+                  </td>
+                  <td><span class="chip live">Live</span></td>
+                  <td>Video Editing</td>
+                  <td>5</td>
+                  <td><button class="btn ghost">Open Profile</button></td>
+                </tr>
+                <tr>
+                  <td>
+                    <div class="avatar-ring"></div>
+                    <div>
+                      <strong>Hassan Lee</strong>
+                      <span class="muted">@hlee</span>
+                    </div>
+                  </td>
+                  <td><span class="chip draft">Draft</span></td>
+                  <td>Podcast Production</td>
+                  <td>2</td>
+                  <td><button class="btn ghost">Open Profile</button></td>
+                </tr>
+                <tr>
+                  <td>
+                    <div class="avatar-ring"></div>
+                    <div>
+                      <strong>Jules Park</strong>
+                      <span class="muted">@jpark</span>
+                    </div>
+                  </td>
+                  <td><span class="chip done">Done</span></td>
+                  <td>Copywriting</td>
+                  <td>9</td>
+                  <td><button class="btn ghost">Open Profile</button></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="profile-tabs">
+            <div class="tab-buttons">
+              <button class="tab active" data-tab="overview">Overview</button>
+              <button class="tab" data-tab="projects">Projects</button>
+              <button class="tab" data-tab="payouts">Payouts</button>
+            </div>
+            <div class="tab-content active" id="overview">
+              <h2>Profile Spotlight</h2>
+              <p>Hero banner with glowing avatar ring, featuring success metrics and social reach.</p>
+            </div>
+            <div class="tab-content" id="projects">
+              <h2>Project Timeline</h2>
+              <p>Stacked cards showing milestones, due dates, and role contributions.</p>
+            </div>
+            <div class="tab-content" id="payouts">
+              <h2>Payout History</h2>
+              <p>Summaries with neon-accented totals and Stripe references.</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="section" id="admin-projects">
+          <h1>Projects &amp; Tasks</h1>
+          <div class="projects-grid">
+            <article class="project-card" data-status="draft">
+              <header>
+                <span>Draft</span>
+                <h2>AI Voices Launch</h2>
+              </header>
+              <p>Prep assets, finalize scripts, coordinate beta creators.</p>
+            </article>
+            <article class="project-card" data-status="live">
+              <header>
+                <span>Live</span>
+                <h2>Creator Labs Beta</h2>
+              </header>
+              <p>Active sprint with 8 creators, progress updates daily.</p>
+            </article>
+            <article class="project-card" data-status="done">
+              <header>
+                <span>Done</span>
+                <h2>Influencer Outreach</h2>
+              </header>
+              <p>Wrap-up, analytics ready for stakeholder report.</p>
+            </article>
+          </div>
+
+          <div class="task-modal-preview">
+            <div class="modal-card">
+              <h2>Create Task</h2>
+              <div class="modal-grid">
+                <label>Title<input type="text" placeholder="Podcast outline" /></label>
+                <label>Due Date<input type="date" /></label>
+                <label>Assignee<input type="text" placeholder="@creator" /></label>
+                <label>Status<select><option>Draft</option><option>Live</option><option>Done</option></select></label>
+              </div>
+              <button class="btn primary">Save Task</button>
+            </div>
+            <div class="live-dashboard">
+              <h2>Live Task Dashboard</h2>
+              <div class="progress-bar"><span style="width: 68%"></span></div>
+              <div class="mini-avatars">
+                <span title="Vera"></span>
+                <span title="Hassan"></span>
+                <span title="Jules"></span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="section" id="admin-review">
+          <h1>Review &amp; Submissions</h1>
+          <div class="review-modal">
+            <div class="review-card">
+              <h2>Submission Review</h2>
+              <p>Check deliverables with contextual notes, timeline comparisons, and version diff previews.</p>
+              <div class="btn-row">
+                <button class="btn primary">Approve</button>
+                <button class="btn warning">Request Changes</button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="section" id="admin-payouts">
+          <h1>Payouts &amp; Finance</h1>
+          <div class="ledger">
+            <table>
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Creator</th>
+                  <th>Amount</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Aug 25</td>
+                  <td>Vera Lang</td>
+                  <td class="amount paid">$1,800</td>
+                  <td><span class="chip done">Paid</span></td>
+                </tr>
+                <tr>
+                  <td>Aug 25</td>
+                  <td>Hassan Lee</td>
+                  <td class="amount pending">$950</td>
+                  <td><span class="chip live">Processing</span></td>
+                </tr>
+                <tr>
+                  <td>Aug 24</td>
+                  <td>Jules Park</td>
+                  <td class="amount paid">$600</td>
+                  <td><span class="chip done">Paid</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="stripe-modal">
+            <div class="stripe-frame">
+              <h2>Stripe Connect</h2>
+              <p>Securely onboarded. Re-authenticate if connection expires.</p>
+              <button class="btn success">Sync Now</button>
+            </div>
+            <div class="success-glow">
+              <h3>Success Animation</h3>
+              <p>Upon payout completion, trigger a green-glow pulse animation with confetti burst.</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="section" id="creator-onboarding">
+          <h1>Creator Onboarding Journey</h1>
+          <div class="journey-grid">
+            <article class="journey-card">
+              <h2>Hero Welcome</h2>
+              <p>Full-screen illustration with AI community vibes, plus glowing CTA.</p>
+            </article>
+            <article class="journey-card">
+              <h2>Profile Form</h2>
+              <p>Tag inputs appear as neon pills with remove icons.</p>
+            </article>
+            <article class="journey-card">
+              <h2>Payout Setup</h2>
+              <p>Embedded Stripe Connect dark theme with accent frame.</p>
+            </article>
+            <article class="journey-card">
+              <h2>KYC Wizard</h2>
+              <p>Step indicators glow with subtle pulsing on the active step.</p>
+            </article>
+            <article class="journey-card">
+              <h2>Contract Signing</h2>
+              <p>Signature pad with accent outline and confirmation check spark.</p>
+            </article>
+            <article class="journey-card wide">
+              <h2>Success Screen</h2>
+              <p>Confetti gradient animation celebrating completion with a centered bright CTA.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section" id="creator-dashboard">
+          <h1>Creator Dashboard &amp; Tasks</h1>
+          <div class="creator-dashboard">
+            <div class="creator-metrics">
+              <div class="metric-card" data-glow="blue">
+                <span class="label">Active Tasks</span>
+                <strong class="value">3</strong>
+                <span class="trend positive">Due in 2 days</span>
+              </div>
+              <div class="metric-card" data-glow="green">
+                <span class="label">Earnings</span>
+                <strong class="value">$4,520</strong>
+                <span class="trend positive">+22% this month</span>
+              </div>
+              <div class="metric-card" data-glow="violet">
+                <span class="label">Completion Rate</span>
+                <strong class="value">97%</strong>
+                <span class="trend positive">Top percentile</span>
+              </div>
+            </div>
+            <div class="task-detail">
+              <h2>Current Task</h2>
+              <p>Polish AI audio mix for Episode 4. Deliver stems and transcripts.</p>
+              <button class="btn primary">Accept Task</button>
+            </div>
+            <div class="submission-form">
+              <h2>Submit Deliverable</h2>
+              <div class="drop-zone" tabindex="0">
+                <p>Drag &amp; drop files or click to browse.</p>
+              </div>
+              <button class="btn outline">Upload</button>
+            </div>
+            <div class="submission-status">
+              <h2>Status</h2>
+              <p>Awaiting Review <span class="pulse"></span></p>
+            </div>
+          </div>
+        </section>
+
+        <section class="section" id="creator-earnings">
+          <h1>Creator Earnings &amp; Stripe Flow</h1>
+          <div class="earnings-overview">
+            <div class="balance">$12,420.00</div>
+            <p>Track payouts with neon clarity and instant Stripe Express access.</p>
+            <div class="stripe-express">
+              <h2>Stripe Express</h2>
+              <p>Dark themed embed with accent ring and secure authentication.</p>
+              <button class="btn success">Open Stripe</button>
+            </div>
+            <div class="success-modal">
+              <h3>Success Modal</h3>
+              <p>Green glow, checkmark burst animation, and success copy.</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="section" id="components">
+          <h1>Component Library</h1>
+          <div class="component-library">
+            <div>
+              <h2>Atoms</h2>
+              <ul>
+                <li>Buttons: primary, secondary, destructive, ghost.</li>
+                <li>Inputs, dropdowns, tags, toasts.</li>
+              </ul>
+            </div>
+            <div>
+              <h2>Molecules</h2>
+              <ul>
+                <li>Cards, tables, modals, tab bars, step indicators.</li>
+                <li>Progress bars, activity timelines.</li>
+              </ul>
+            </div>
+            <div>
+              <h2>Organisms</h2>
+              <ul>
+                <li>Dashboard panels, profile header, task list, onboarding wizard.</li>
+              </ul>
+            </div>
+            <div>
+              <h2>Global Styles</h2>
+              <ul>
+                <li>Color tokens, text styles, shadows, radii, animations.</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,84 @@
+const navButtons = Array.from(document.querySelectorAll('.nav-btn'));
+const sections = Array.from(document.querySelectorAll('.section'));
+const tabs = Array.from(document.querySelectorAll('.profile-tabs .tab'));
+const tabContents = Array.from(document.querySelectorAll('.profile-tabs .tab-content'));
+const dropZone = document.querySelector('.drop-zone');
+const themeToggle = document.getElementById('themeToggle');
+let glowMode = false;
+
+navButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    const sectionId = button.dataset.section;
+    navButtons.forEach((btn) => btn.classList.toggle('active', btn === button));
+    sections.forEach((section) => {
+      section.classList.toggle('active', section.id === sectionId);
+      if (section.id === sectionId) {
+        section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  });
+});
+
+tabs.forEach((tab) => {
+  tab.addEventListener('click', () => {
+    tabs.forEach((btn) => btn.classList.toggle('active', btn === tab));
+    tabContents.forEach((content) => {
+      content.classList.toggle('active', content.id === tab.dataset.tab);
+    });
+  });
+});
+
+if (dropZone) {
+  ['dragenter', 'dragover'].forEach((eventName) => {
+    dropZone.addEventListener(eventName, (event) => {
+      event.preventDefault();
+      dropZone.classList.add('drag-hover');
+    });
+  });
+
+  ['dragleave', 'drop'].forEach((eventName) => {
+    dropZone.addEventListener(eventName, (event) => {
+      event.preventDefault();
+      dropZone.classList.remove('drag-hover');
+    });
+  });
+
+  dropZone.addEventListener('drop', (event) => {
+    const files = Array.from(event.dataTransfer.files).map((file) => file.name).join(', ');
+    dropZone.querySelector('p').textContent = files || 'Files uploaded!';
+  });
+
+  dropZone.addEventListener('click', () => {
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.multiple = true;
+    fileInput.addEventListener('change', () => {
+      const files = Array.from(fileInput.files).map((file) => file.name).join(', ');
+      dropZone.querySelector('p').textContent = files || 'Files uploaded!';
+    });
+    fileInput.click();
+  });
+}
+
+if (themeToggle) {
+  themeToggle.addEventListener('click', () => {
+    glowMode = !glowMode;
+    document.body.classList.toggle('glow-mode', glowMode);
+    themeToggle.textContent = glowMode ? 'Glow Active' : 'Glow Boost';
+  });
+}
+
+const observer = new IntersectionObserver(
+  (entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+      }
+    });
+  },
+  {
+    threshold: 0.2,
+  }
+);
+
+sections.forEach((section) => observer.observe(section));

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,998 @@
+:root {
+  color-scheme: dark;
+  --bg-primary: #0e0e10;
+  --bg-surface: #18181b;
+  --bg-elevated: #1f1f23;
+  --text-primary: #f5f5f5;
+  --text-secondary: #a1a1aa;
+  --border: #27272a;
+  --hover: #3f3f46;
+  --accent-blue: #3b82f6;
+  --accent-violet: #8b5cf6;
+  --accent-green: #22c55e;
+  --accent-yellow: #facc15;
+  --accent-red: #ef4444;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  --shadow-glow: 0 0 24px rgba(59, 130, 246, 0.35);
+  --shadow-soft: 0 18px 32px rgba(10, 10, 15, 0.65);
+  --transition: all 160ms ease-out;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.12), transparent 55%),
+    var(--bg-primary);
+  color: var(--text-primary);
+  display: flex;
+}
+
+a {
+  color: var(--accent-blue);
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  width: 100%;
+}
+
+.sidebar {
+  background: linear-gradient(180deg, rgba(139, 92, 246, 0.18) 0%, rgba(24, 24, 27, 0.88) 40%, #0e0e10 100%);
+  border-right: 1px solid rgba(59, 130, 246, 0.12);
+  padding: 32px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+
+.logo {
+  font-family: "JetBrains Mono", monospace;
+  font-weight: 600;
+  font-size: 1.3rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nav-btn {
+  width: 100%;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-secondary);
+  padding: 10px 12px;
+  border-radius: 10px;
+  text-align: left;
+  font-family: "Inter", sans-serif;
+  transition: var(--transition);
+  cursor: pointer;
+}
+
+.nav-btn:hover,
+.nav-btn:focus-visible {
+  border-color: rgba(139, 92, 246, 0.4);
+  background: rgba(139, 92, 246, 0.16);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.nav-btn.active {
+  border-color: rgba(59, 130, 246, 0.6);
+  background: rgba(59, 130, 246, 0.18);
+  color: var(--text-primary);
+  box-shadow: 0 0 16px rgba(59, 130, 246, 0.35);
+}
+
+.divider {
+  height: 1px;
+  background: rgba(39, 39, 42, 0.9);
+  margin: 12px 0;
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  opacity: 0.7;
+}
+
+.content {
+  background: linear-gradient(150deg, rgba(59, 130, 246, 0.12), transparent 40%),
+    linear-gradient(320deg, rgba(139, 92, 246, 0.08), transparent 60%),
+    var(--bg-primary);
+  padding: 32px 48px;
+  overflow-y: auto;
+  height: 100vh;
+}
+
+.top-bar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  margin: -32px -48px 32px;
+  backdrop-filter: blur(12px);
+  background: rgba(26, 26, 29, 0.8);
+  border-bottom: 1px solid rgba(39, 39, 42, 0.8);
+  z-index: 10;
+}
+
+.search-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(15, 15, 20, 0.8);
+  color: var(--text-secondary);
+}
+
+.search-wrapper input {
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.9rem;
+  width: 220px;
+}
+
+.search-wrapper input:focus {
+  outline: none;
+}
+
+.theme-toggle {
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.6), rgba(59, 130, 246, 0.2));
+  border: 1px solid rgba(59, 130, 246, 0.5);
+  color: var(--text-primary);
+  font-family: "JetBrains Mono", monospace;
+  text-transform: uppercase;
+  padding: 8px 16px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: var(--transition);
+  box-shadow: 0 0 20px rgba(59, 130, 246, 0.35);
+}
+
+.theme-toggle:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 0 28px rgba(139, 92, 246, 0.45);
+}
+
+.section {
+  display: none;
+  animation: fade-in 240ms ease-out both;
+}
+
+.section.active {
+  display: block;
+}
+
+h1 {
+  font-size: 2rem;
+  margin-bottom: 24px;
+}
+
+p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 32px;
+  margin-bottom: 40px;
+  align-items: center;
+}
+
+.hero-content {
+  padding: 32px;
+  background: rgba(24, 24, 27, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+}
+
+.hero-visual {
+  position: relative;
+  min-height: 280px;
+  border-radius: 24px;
+  background: radial-gradient(circle at 30% 30%, rgba(59, 130, 246, 0.45), transparent 60%),
+    radial-gradient(circle at 70% 60%, rgba(139, 92, 246, 0.35), transparent 70%),
+    rgba(12, 12, 15, 0.7);
+  overflow: hidden;
+}
+
+.glow-orb,
+.orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(2px);
+  animation: float 6s ease-in-out infinite;
+}
+
+.glow-orb {
+  width: 160px;
+  height: 160px;
+  background: rgba(59, 130, 246, 0.4);
+  top: 20%;
+  left: 20%;
+}
+
+.orb {
+  width: 90px;
+  height: 90px;
+  background: rgba(139, 92, 246, 0.35);
+  top: 50%;
+  left: 60%;
+}
+
+.orb.trail {
+  width: 120px;
+  height: 120px;
+  background: rgba(250, 204, 21, 0.3);
+  top: 65%;
+  left: 30%;
+  animation-delay: 1.2s;
+}
+
+.cta-group {
+  display: flex;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.btn {
+  font-family: "JetBrains Mono", monospace;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 20px;
+  cursor: pointer;
+  transition: var(--transition);
+  font-size: 0.9rem;
+}
+
+.btn.primary {
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.95), rgba(139, 92, 246, 0.85));
+  color: #fff;
+  box-shadow: 0 0 24px rgba(59, 130, 246, 0.45);
+}
+
+.btn.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 0 28px rgba(139, 92, 246, 0.6);
+}
+
+.btn.secondary {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid rgba(139, 92, 246, 0.5);
+}
+
+.btn.outline {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid rgba(59, 130, 246, 0.5);
+}
+
+.btn.warning {
+  background: linear-gradient(120deg, rgba(250, 204, 21, 0.9), rgba(250, 204, 21, 0.55));
+  color: #1a1a1a;
+  box-shadow: 0 0 18px rgba(250, 204, 21, 0.35);
+}
+
+.btn.success {
+  background: linear-gradient(120deg, rgba(34, 197, 94, 0.95), rgba(16, 185, 129, 0.85));
+  color: #061107;
+  box-shadow: 0 0 18px rgba(34, 197, 94, 0.4);
+}
+
+.btn.ghost {
+  background: rgba(39, 39, 42, 0.6);
+  color: var(--text-secondary);
+  border-radius: 12px;
+  padding: 8px 14px;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  filter: brightness(1.05);
+  transform: translateY(-1px);
+}
+
+.flow-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.card {
+  padding: 24px;
+  border-radius: var(--radius-sm);
+  background: rgba(24, 24, 27, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4);
+}
+
+.card.gradient {
+  background: linear-gradient(140deg, rgba(59, 130, 246, 0.16), rgba(12, 12, 16, 0.86));
+}
+
+.card.wide {
+  grid-column: span 2;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+  margin-bottom: 32px;
+}
+
+.metric-card {
+  padding: 22px;
+  border-radius: 18px;
+  background: rgba(24, 24, 27, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.metric-card::before {
+  content: "";
+  position: absolute;
+  inset: -40%;
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.25), transparent 60%);
+  opacity: 0.6;
+  transition: opacity 200ms ease-out;
+}
+
+.metric-card[data-glow="violet"]::before {
+  background: radial-gradient(circle, rgba(139, 92, 246, 0.25), transparent 60%);
+}
+
+.metric-card[data-glow="green"]::before {
+  background: radial-gradient(circle, rgba(34, 197, 94, 0.25), transparent 60%);
+}
+
+.metric-card[data-glow="yellow"]::before {
+  background: radial-gradient(circle, rgba(250, 204, 21, 0.25), transparent 60%);
+}
+
+.metric-card:hover::before {
+  opacity: 0.9;
+}
+
+.metric-card .label {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.metric-card .value {
+  display: block;
+  font-size: 2.2rem;
+  margin: 12px 0;
+}
+
+.metric-card .trend {
+  font-size: 0.85rem;
+  color: var(--accent-yellow);
+}
+
+.metric-card .trend.positive {
+  color: var(--accent-green);
+}
+
+.metric-card .trend.warning {
+  color: var(--accent-yellow);
+}
+
+.dashboard-layout {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 24px;
+}
+
+.activity-feed,
+.hint-overlay {
+  background: rgba(24, 24, 27, 0.8);
+  border-radius: 20px;
+  padding: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  position: relative;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 8px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(to bottom, rgba(59, 130, 246, 0.5), rgba(139, 92, 246, 0.1));
+}
+
+.timeline li {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: 16px;
+}
+
+.timeline .dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.9), rgba(139, 92, 246, 0.7));
+  box-shadow: 0 0 12px rgba(139, 92, 246, 0.5);
+  margin-top: 6px;
+}
+
+.highlight {
+  color: var(--accent-blue);
+}
+
+.table-wrapper {
+  background: rgba(24, 24, 27, 0.85);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+  margin-bottom: 32px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+th,
+td {
+  padding: 16px 18px;
+}
+
+th {
+  text-align: left;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  background: rgba(30, 30, 35, 0.8);
+}
+
+tbody tr:nth-child(odd) {
+  background: rgba(24, 24, 27, 0.92);
+}
+
+tbody tr:nth-child(even) {
+  background: rgba(31, 31, 35, 0.88);
+}
+
+tbody tr:hover {
+  background: rgba(63, 63, 70, 0.28);
+}
+
+.avatar-ring {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 2px solid rgba(139, 92, 246, 0.8);
+  margin-right: 12px;
+  display: inline-block;
+}
+
+.avatar-ring.active {
+  border-color: rgba(59, 130, 246, 0.9);
+  box-shadow: 0 0 12px rgba(59, 130, 246, 0.6);
+}
+
+tbody td:first-child {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.muted {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.chip.live {
+  background: rgba(59, 130, 246, 0.25);
+  color: var(--accent-blue);
+}
+
+.chip.draft {
+  background: rgba(161, 161, 170, 0.2);
+  color: var(--text-secondary);
+}
+
+.chip.done {
+  background: rgba(34, 197, 94, 0.25);
+  color: var(--accent-green);
+}
+
+.profile-tabs {
+  background: rgba(24, 24, 27, 0.8);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 24px;
+}
+
+.tab-buttons {
+  display: inline-flex;
+  background: rgba(39, 39, 42, 0.8);
+  border-radius: 999px;
+  padding: 4px;
+}
+
+.tab {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  padding: 10px 20px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: var(--transition);
+  font-family: "Inter", sans-serif;
+}
+
+.tab.active {
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.9), rgba(139, 92, 246, 0.7));
+  color: #fff;
+  box-shadow: 0 0 16px rgba(59, 130, 246, 0.4);
+}
+
+.tab-content {
+  display: none;
+  margin-top: 20px;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+  margin-bottom: 32px;
+}
+
+.project-card {
+  padding: 24px;
+  border-radius: 18px;
+  background: linear-gradient(140deg, rgba(18, 18, 21, 0.9), rgba(24, 24, 27, 0.75));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: 0 0 22px rgba(0, 0, 0, 0.35);
+}
+
+.project-card[data-status="draft"] span {
+  color: var(--text-secondary);
+}
+
+.project-card[data-status="live"] span {
+  color: var(--accent-blue);
+}
+
+.project-card[data-status="done"] span {
+  color: var(--accent-green);
+}
+
+.task-modal-preview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.modal-card {
+  background: rgba(24, 24, 27, 0.85);
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow-soft);
+}
+
+.modal-grid {
+  display: grid;
+  gap: 12px;
+  margin: 20px 0;
+}
+
+.modal-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.modal-grid input,
+.modal-grid select {
+  background: rgba(15, 15, 20, 0.9);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  padding: 10px 12px;
+  border-radius: 12px;
+  color: var(--text-primary);
+  font-family: "JetBrains Mono", monospace;
+}
+
+.modal-grid input:focus,
+.modal-grid select:focus {
+  outline: 1px solid rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+}
+
+.live-dashboard {
+  background: rgba(18, 18, 21, 0.88);
+  border-radius: 20px;
+  padding: 24px;
+  border: 1px solid rgba(34, 197, 94, 0.25);
+  box-shadow: 0 0 24px rgba(34, 197, 94, 0.25);
+}
+
+.progress-bar {
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(39, 39, 42, 0.8);
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+.progress-bar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0.9), rgba(139, 92, 246, 0.9));
+  animation: progress 2.5s ease-in-out infinite alternate;
+}
+
+.mini-avatars {
+  display: flex;
+  gap: 12px;
+}
+
+.mini-avatars span {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.8), rgba(139, 92, 246, 0.6));
+  box-shadow: 0 0 12px rgba(139, 92, 246, 0.5);
+}
+
+.review-modal {
+  background: rgba(14, 14, 16, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 24px;
+  padding: 32px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0 0 30px rgba(0, 0, 0, 0.6);
+}
+
+.review-card {
+  max-width: 420px;
+  text-align: center;
+}
+
+.btn-row {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  margin-top: 24px;
+}
+
+.ledger {
+  background: rgba(24, 24, 27, 0.8);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  margin-bottom: 32px;
+  overflow: hidden;
+}
+
+.amount {
+  text-align: right;
+  font-family: "JetBrains Mono", monospace;
+}
+
+.amount.paid {
+  color: var(--accent-green);
+}
+
+.amount.pending {
+  color: var(--accent-yellow);
+}
+
+.stripe-modal {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.stripe-frame {
+  background: linear-gradient(130deg, rgba(59, 130, 246, 0.4), rgba(10, 10, 12, 0.95));
+  border-radius: 20px;
+  padding: 24px;
+  border: 1px solid rgba(59, 130, 246, 0.45);
+  box-shadow: 0 0 28px rgba(59, 130, 246, 0.35);
+}
+
+.success-glow {
+  background: rgba(14, 14, 16, 0.85);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: 0 0 24px rgba(34, 197, 94, 0.2);
+}
+
+.journey-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.journey-card {
+  padding: 24px;
+  border-radius: 20px;
+  background: linear-gradient(150deg, rgba(15, 15, 20, 0.9), rgba(31, 31, 35, 0.75));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.journey-card.wide {
+  grid-column: span 2;
+}
+
+.creator-dashboard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.creator-metrics {
+  display: contents;
+}
+
+.task-detail,
+.submission-form,
+.submission-status {
+  background: rgba(24, 24, 27, 0.85);
+  border-radius: 18px;
+  padding: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.drop-zone {
+  border: 2px dashed rgba(255, 255, 255, 0.25);
+  border-radius: 16px;
+  padding: 32px;
+  text-align: center;
+  background: rgba(14, 14, 16, 0.8);
+  transition: var(--transition);
+}
+
+.drop-zone:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 20px rgba(59, 130, 246, 0.4);
+}
+
+.submission-status .pulse {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent-yellow);
+  box-shadow: 0 0 12px rgba(250, 204, 21, 0.6);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.earnings-overview {
+  background: rgba(24, 24, 27, 0.85);
+  border-radius: 22px;
+  padding: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  display: grid;
+  gap: 24px;
+  justify-items: start;
+}
+
+.balance {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 2.4rem;
+  letter-spacing: 0.04em;
+  background: linear-gradient(120deg, rgba(59, 130, 246, 1), rgba(139, 92, 246, 0.8));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.stripe-express,
+.success-modal {
+  background: rgba(14, 14, 16, 0.85);
+  border-radius: 18px;
+  padding: 24px;
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  box-shadow: 0 0 20px rgba(59, 130, 246, 0.25);
+}
+
+.success-modal {
+  border-color: rgba(34, 197, 94, 0.35);
+  box-shadow: 0 0 24px rgba(34, 197, 94, 0.25);
+}
+
+.component-library {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+  background: rgba(24, 24, 27, 0.8);
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.component-library h2 {
+  font-size: 1.1rem;
+  margin-bottom: 12px;
+}
+
+.component-library ul {
+  padding-left: 18px;
+  color: var(--text-secondary);
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(-8px) scale(1);
+  }
+  50% {
+    transform: translateY(8px) scale(1.04);
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(0.9);
+    opacity: 0.7;
+  }
+  50% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
+}
+
+@keyframes progress {
+  0% {
+    transform: translateX(-5%);
+  }
+  100% {
+    transform: translateX(5%);
+  }
+}
+
+@media (max-width: 1080px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+  .sidebar {
+    position: static;
+    height: auto;
+    flex-direction: row;
+    overflow-x: auto;
+    background: rgba(18, 18, 21, 0.95);
+    border-right: none;
+    border-bottom: 1px solid rgba(59, 130, 246, 0.2);
+  }
+  .sidebar nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+  .nav-btn {
+    flex: 1 1 180px;
+  }
+  .content {
+    padding: 24px;
+  }
+  .top-bar {
+    margin: -24px -24px 24px;
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+  .dashboard-layout {
+    grid-template-columns: 1fr;
+  }
+  .task-modal-preview {
+    grid-template-columns: 1fr;
+  }
+  .stripe-modal {
+    grid-template-columns: 1fr;
+  }
+}
+
+.drop-zone.drag-hover {
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 24px rgba(59, 130, 246, 0.4);
+  background: rgba(24, 24, 30, 0.95);
+}
+
+body.glow-mode {
+  background: linear-gradient(160deg, rgba(59, 130, 246, 0.18), rgba(15, 15, 18, 0.95)),
+    linear-gradient(320deg, rgba(139, 92, 246, 0.15), transparent 55%),
+    var(--bg-primary);
+}
+
+body.glow-mode .metric-card,
+body.glow-mode .project-card,
+body.glow-mode .journey-card,
+body.glow-mode .task-detail,
+body.glow-mode .submission-form,
+body.glow-mode .submission-status,
+body.glow-mode .earnings-overview {
+  box-shadow: 0 0 30px rgba(59, 130, 246, 0.25);
+}
+
+body.glow-mode .btn.primary,
+body.glow-mode .btn.success {
+  box-shadow: 0 0 32px rgba(59, 130, 246, 0.35);
+}
+
+.section.visible .card,
+.section.visible .metric-card,
+.section.visible .project-card,
+.section.visible .journey-card,
+.section.visible .task-detail,
+.section.visible .submission-form,
+.section.visible .submission-status,
+.section.visible .earnings-overview {
+  transition: transform 220ms ease-out, box-shadow 220ms ease-out;
+  transform: translateY(-4px);
+}


### PR DESCRIPTION
## Summary
- add a static frontend that maps to the admin and creator flows described in the dark mode brief
- implement glowing dark theme styling, navigation, and micro-interactions in vanilla HTML, CSS, and JavaScript
- update the README with instructions for previewing and a summary of included components

## Testing
- not run (static assets only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f2f38e7f4832c91150fa66cede2ef)